### PR TITLE
fix: errors while BundleUpdate

### DIFF
--- a/plugin/linuxsty.vim
+++ b/plugin/linuxsty.vim
@@ -8,7 +8,7 @@
 " and various user comments.
 
 if exists("g:loaded_linuxsty")
-    finish
+    finish
 endif
 let g:loaded_linuxsty = 1
 


### PR DESCRIPTION
I had such an error while BundleUpdate:
Error detected while processing /home/dedxoxo/.vim/bundle/kernel-coding-style/plugin/linuxsty.vim:
line   11:
E492: Not an editor command: <a0><a0><a0><a0>finish